### PR TITLE
Move page navi to index.php

### DIFF
--- a/templates/index-loop.php
+++ b/templates/index-loop.php
@@ -26,6 +26,4 @@
 
 	</article>
 
-	<?php get_template_part( 'templates/post-navigation'); ?>
-
 <?php endwhile; endif; ?>


### PR DESCRIPTION
Address issue when Wordpress is set to summery - the page navi then displays below each snippet rather than below all snippets.