### PR TITLE
Move page navi to index.php

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -8,6 +8,7 @@
 
 				<?php // Edit the loop in /templates/archive-loop. Or roll your own. ?>
 				<?php get_template_part( 'templates/archive', 'loop'); ?>
+				<?php get_template_part( 'templates/post-navigation'); ?>
 
 			</main>
 


### PR DESCRIPTION
Address issue when Wordpress is set to summery - the page navi then displays below each snippet rather than below all snippets.