### PR TITLE
Move page navi to index.php

### DIFF
--- a/templates/archive-loop.php
+++ b/templates/archive-loop.php
@@ -38,6 +38,4 @@ the_archive_description( '<div class="taxonomy-description">', '</div>' );
 
 	</article>
 
-<?php get_template_part( 'templates/post-navigation'); ?>
-
 <?php endwhile; endif; ?>


### PR DESCRIPTION
Address issue when Wordpress is set to summery - the page navi then displays below each snippet rather than below all snippets.